### PR TITLE
Fix: relative path global call

### DIFF
--- a/python_judge_main/config.py
+++ b/python_judge_main/config.py
@@ -13,12 +13,13 @@ parser.add_argument("--executable", help="path to executable solution, will over
 parser.add_argument("--solution", help="solution file path", default="./solution.cpp", required=False)
 parser.add_argument("--scorer", help="scorer file path", default="./helper/scorer.cpp", required=False)
 parser.add_argument("--test-dir", help="directory containing test cases", default="./tests", required=False)
+parser.add_argument("--config", help="config file path", default="./config.yml", required=False)
 
 # Parse the command-line arguments
 args = parser.parse_args()
 
 # Parsing yaml config
-with open('./config.yml', 'r') as file:
+with open(args.config, 'r') as file:
   judge_config = yaml.safe_load(file)
 
 class Config:

--- a/python_judge_main/config.py
+++ b/python_judge_main/config.py
@@ -2,6 +2,12 @@ import argparse
 import yaml
 import os
 
+from . import utils
+
+# Example: Go to parent directory until "python-judge" is found
+MODULE_NAME = 'python-judge'
+ROOT_DIRECTORY = utils.get_module_root_directory(MODULE_NAME)
+
 # Create the argument parser
 parser = argparse.ArgumentParser()
 
@@ -10,10 +16,10 @@ parser.add_argument('-v', '--verbose', help='will also print error message if rt
 parser.add_argument('-b', '--brief', help='only print the results', action="store_true")
 parser.add_argument("--beta-mode", help="beta mode, uses cpu time to measure time limit", action="store_true")
 parser.add_argument("--executable", help="path to executable solution, will override solution", default=None, required=False)
-parser.add_argument("--solution", help="solution file path", default="./solution.cpp", required=False)
-parser.add_argument("--scorer", help="scorer file path", default="./helper/scorer.cpp", required=False)
-parser.add_argument("--test-dir", help="directory containing test cases", default="./tests", required=False)
-parser.add_argument("--config", help="config file path", default="./config.yml", required=False)
+parser.add_argument("--solution", help="solution file path", default=f"{ROOT_DIRECTORY}/solution.cpp", required=False)
+parser.add_argument("--scorer", help="scorer file path", default=f"{ROOT_DIRECTORY}/helper/scorer.cpp", required=False)
+parser.add_argument("--test-dir", help="directory containing test cases", default=f"{ROOT_DIRECTORY}/tests", required=False)
+parser.add_argument("--config", help="config file path", default=f"{ROOT_DIRECTORY}/config.yml", required=False)
 
 # Parse the command-line arguments
 args = parser.parse_args()
@@ -35,9 +41,9 @@ class Config:
   CON_CPP_PATH = args.solution
   SCORER_CPP_PATH = args.scorer
 
-  CON_OUTPUT_PATH = "./temp/contestant"
-  CON_SOLUTION_PATH = "./temp/solution.exe"
-  SCORER_PATH = "./temp/scorer.exe"
+  CON_OUTPUT_PATH = f"{ROOT_DIRECTORY}/temp/contestant"
+  CON_SOLUTION_PATH = f"{ROOT_DIRECTORY}/temp/solution.exe"
+  SCORER_PATH = f"{ROOT_DIRECTORY}/temp/scorer.exe"
 
   if EXECUTABLE_PATH != None:
     CON_SOLUTION_PATH = EXECUTABLE_PATH

--- a/python_judge_main/utils.py
+++ b/python_judge_main/utils.py
@@ -1,0 +1,13 @@
+import os
+
+def get_module_root_directory(directory_name):
+    current_directory = os.path.abspath(__file__)
+
+    while os.path.basename(current_directory) != directory_name:
+        current_directory = os.path.dirname(current_directory)
+
+        # Check if reached the root directory
+        if current_directory == os.path.dirname(current_directory):
+            raise ValueError(f"Directory '{directory_name}' not found in the path.")
+
+    return current_directory

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 Used to test solution and scorer based on public test data. 
 
 ```bash
-usage: main.py [-h] [-v] [-b] [--beta-mode] [--solution SOLUTION] [--scorer SCORER] [--test-dir TEST_DIR]
+usage: main.py [-h] [-v] [-b] [--beta-mode] [--solution SOLUTION] [--scorer SCORER] [--test-dir TEST_DIR] [--config CONFIG]
 
 optional arguments:
   -h, --help           show this help message and exit
@@ -11,4 +11,22 @@ optional arguments:
   --solution SOLUTION  solution file path
   --scorer SCORER      scorer file path
   --test-dir TEST_DIR  directory containing test cases
+  --config CONFIG      config file path
 ```
+
+## Installation for Global Call
+
+1. Clone this repository and navigate to the directory.
+
+2. Enable execution permissions on `start.sh`
+
+```
+chmod +x start.sh
+```
+
+3. Add the following alias to `~/.bashrc`. Change `~/path/to/python-judge/` to the path where the repository directory is located.
+
+```
+alias "python-judge"="~/path/to/python-judge/start.sh"
+```
+

--- a/start.sh
+++ b/start.sh
@@ -10,6 +10,5 @@ for var in "$@"; do
 done
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-cd $SCRIPT_DIR
 
-python main.py ${param[*]}
+python $SCRIPT_DIR/main.py ${param[*]}

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+param=()
+
+for var in "$@"; do
+  if ! [[ $var == "-"* ]]; then
+    var="$(realpath $var)"
+  fi
+  param+=($var)
+done
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR
+
+python main.py ${param[*]}


### PR DESCRIPTION
### Description

Enable user to call relative path with other method and move the responsibility to handle that to python script instead of start script. Refer to 

### To be Discussed

Is it appropriate to remove realpath modification?
```sh
  if ! [[ $var == "-"* ]]; then
    var="$(realpath $var)"
  fi
  ```